### PR TITLE
Switch to new fluent logger (needed for ES 5)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,8 @@ var internals = {
     defaults: {
         host: 'localhost',
         port: 24224,
-        timeout: 3,
+        timeout: 30 * 1000,
+        reconnectInterval: 1 * 1000,
         filter: function() {
           return true;
         },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "fluent-logger": "^0.5.0",
+    "fluent-logger": "^2.2.0",
     "good-squeeze": "2.x.x",
     "hoek": "2.x.x",
     "through2": "0.6.x"


### PR DESCRIPTION
Rationalize timeout settings